### PR TITLE
Update CC BY-SA license to 4.0.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@ baseurl: http://docs-china.com/rails
 home: http://docs-china.com
 repo: rails
 buy_url: https://leanpub.com/rails-guides-cn
-license: <a href="http://creativecommons.org/licenses/by-sa/3.0/deed.zh" title="CC BY-SA 3.0">CC BY-SA 3.0</a>
+license: <a href="https://creativecommons.org/licenses/by-sa/4.0/deed.zh" title="CC BY-SA 4.0">CC BY-SA 4.0</a>
 
 pages: _docs
 exclude: ['Rakefile', 'Gemfile', 'Gemfile.lock', 'README.md']


### PR DESCRIPTION
Rails Guides now use CC BY-SA 4.0 International.
